### PR TITLE
Fix missing translations and erase remaining english sentences

### DIFF
--- a/content/implement/encoding.ja.md
+++ b/content/implement/encoding.ja.md
@@ -41,7 +41,6 @@ Decoder interface {
 ```
 
 デコーダは、`Reset` メソッドを追加した、リセット可能なデコーダインタフェースを実装することになるかもしれません：
-A decoder may also implement the resettable decoder interface which adds a `Reset` method:
 
 ```go
 // ResettableDecoder is used to determine whether or not a Decoder can be reset and thus
@@ -138,8 +137,6 @@ EncoderFunc func(w io.Writer) Encoder
 ### カスタムエンコーダの利用
 
 カスタムエンコーダを指定するための DSL 関数は [Produces](https://goa.design/reference/goa/design/apidsl/#func-produces-a-name-apidsl-produces-a) です。これは `Consumes` と同じ構文をサポートしています：
-
-it supports the same syntax as `Consumes`:
 
 ```go
 var _ = API("My API", func() {

--- a/content/implement/goagen.ja.md
+++ b/content/implement/goagen.ja.md
@@ -27,8 +27,8 @@ go install github.com/goadesign/goa/goagen
 3. デザインパッケージとツールコードで構成されるツールは、一時ディレクトリでコンパイルされる。
 4. このツールが実行され、最終的な出力を書き込むためにデザインのデータ構造をたどる。
 
-Each generator is exposed via a command of the `goagen` tool, `goagen --help` lists all the available
-commands. These are:
+各ジェネレータは `goagen` ツールのコマンドとして公開され、`goagen --help` で利用可能なすべてのコマンドを一覧できます。
+それらは以下になります：
 
 * [`app`](#gen_app): コントローラー、コンテキスト、メディアタイプ、ユーザータイプなどのサービス定型コードを生成します。
 * [`main`](#gen_main): デフォルトの `main` と同様に、リソースコントローラごとにスケルトンファイルを生成します。
@@ -103,7 +103,6 @@ goaには、
 生成されたコードは、匿名の AMD モジュールを定義し、実際のHTTPリクエストを作成するために [axios](https://github.com/mzabriskie/axios) の promise ベースの JavaScript ライブラリに依存しています。
 
 生成されたモジュールは `axios` クライアントをラップし、API 固有の関数を追加します。たとえば：
-The generated module wraps the `axios` client and adds API specific functions, for example:
 
 ```javascript
 // List all bottles in account optionally filtering by year


### PR DESCRIPTION
訳し忘れと元の英文が残ってしまっているのを見つけたので修正しました．
goa.design-jp の ja ブランチにマージして本家の ja に pr しようとおもいます．